### PR TITLE
Use pathto() to compute relative paths to static files

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,15 +13,16 @@ The project aims for simple implementation, massive scalability, and a rich set
 of features. Cloud computing experts from around the world contribute to the project.
 
 Here's an example configuration::
-[DEFAULT]
-...
-my_ip = 10.0.0.31
-vnc_enabled = True
-vncserver_listen = 0.0.0.0
-vncserver_proxyclient_address = 10.0.0.31
-novncproxy_base_url = http://controller:6080/vnc_auto.html
 
-..note:: Here's an example note. 
+  [DEFAULT]
+  ...
+  my_ip = 10.0.0.31
+  vnc_enabled = True
+  vncserver_listen = 0.0.0.0
+  vncserver_proxyclient_address = 10.0.0.31
+  novncproxy_base_url = http://controller:6080/vnc_auto.html
+
+.. note:: Here's an example note.
 
 Developer Guide
 ===============

--- a/openstackdocstheme/theme/openstackdocs/css.html
+++ b/openstackdocstheme/theme/openstackdocs/css.html
@@ -1,9 +1,9 @@
     <!-- Bootstrap Core CSS -->
-    <link href="_static/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{pathto('_static/css/bootstrap.min.css', 1)}}" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="_static/css/combined.css" rel="stylesheet">
-    <link href="_static/css/styles.css" rel="stylesheet">
+    <link href="{{pathto('_static/css/combined.css', 1)}}" rel="stylesheet">
+    <link href="{{pathto('_static/css/styles.css', 1)}}" rel="stylesheet">
 
 
     <!-- Fonts -->

--- a/openstackdocstheme/theme/openstackdocs/layout.html
+++ b/openstackdocstheme/theme/openstackdocs/layout.html
@@ -69,7 +69,7 @@
 </div>
     <div class="row">
          <div class="col-lg-8 col-md-8 col-sm-8 docs-license">
-                    <img src="_static/images/docs/license.jpg" alt="Creative Commons Attribution Share Alike 3.0 License"/>
+                    <img src="{{pathto('_static/images/docs/license.jpg', 1)}}" alt="Creative Commons Attribution Share Alike 3.0 License"/>
                     <p>
                         Except where otherwise noted, this document is licensed under Creative Commons Attribution Share Alike 3.0 License
                         <a href="#">http://creativecommons.org/licenses/by-sa/3.0/legalcode</a>.

--- a/openstackdocstheme/theme/openstackdocs/script_footer.html
+++ b/openstackdocstheme/theme/openstackdocs/script_footer.html
@@ -1,16 +1,16 @@
     <!-- jQuery Version 1.11.0 -->
-    <script type="text/javascript" src="_static/jquery/jquery-1.11.0.js"></script>
+    <script type="text/javascript" src="{{pathto('_static/jquery/jquery-1.11.0.js', 1)}}"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script type="text/javascript" src="_static/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="{{pathto('_static/js/bootstrap.min.js', 1)}}"></script>
 
     <!-- The rest of the JS -->
-    <script type="text/javascript" src="_static/js/navigation.js"></script>
+    <script type="text/javascript" src="{{pathto('_static/js/navigation.js', 1)}}"></script>
 
     <!-- Docs JS -->
-    <script type="text/javascript" src="_static/js/docs.js"></script>
+    <script type="text/javascript" src="{{pathto('_static/js/docs.js', 1)}}"></script>
 
     <!-- Popovers -->
-    <script type="text/javascript" src="_static/js/webui-popover.js"></script>
+    <script type="text/javascript" src="{{pathto('_static/js/webui-popover.js', 1)}}"></script>
 
     <!-- Javascript for page -->


### PR DESCRIPTION
Rather than linking directly to the static files, use pathto() to
compute a relative path from a given page.
